### PR TITLE
example.com no longer works, use an alternative

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var once = require('once')
 module.exports = function (cb) {
   var socket = net.connect({
     port: 80,
-    host: 'example.com'
+    host: 'nodejs.org'
   })
 
   // If no 'error' or 'connect' event after 5s, assume network is down


### PR DESCRIPTION
Currently example.com does not return anything on a ping. I've used nodejs.org since I would hope that site would theoretically be up as long as this module is used. Happy to tweak that to something else if needed!